### PR TITLE
Move @types/react-confetti to dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2909,8 +2909,7 @@
     "@types/canvas-confetti": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@types/canvas-confetti/-/canvas-confetti-1.3.0.tgz",
-      "integrity": "sha512-vfShQvbd7XD+jT2bFTju5oALkzI5uMO7RGH8RYOTP8p5LiY9NXSr0fJp2BvfW36Qf8807ma/yev0aS5GRwQcFg==",
-      "dev": true
+      "integrity": "sha512-vfShQvbd7XD+jT2bFTju5oALkzI5uMO7RGH8RYOTP8p5LiY9NXSr0fJp2BvfW36Qf8807ma/yev0aS5GRwQcFg=="
     },
     "@types/glob": {
       "version": "7.1.3",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "@storybook/addon-links": "6.1.11",
     "@storybook/react": "6.1.11",
     "@tsconfig/recommended": "1.0.1",
-    "@types/canvas-confetti": "1.3.0",
     "@types/jest": "^26.0.20",
     "@types/react": "17.0.0",
     "@types/react-dom": "17.0.0",
@@ -50,6 +49,7 @@
     "typescript": "4.1.3"
   },
   "dependencies": {
+    "@types/canvas-confetti": "1.3.0",
     "canvas-confetti": "1.3.3"
   },
   "peerDependencies": {


### PR DESCRIPTION
Hi @ulitcos, thanks a lot for your work on this component! It works great, I just found a small TypeScript bug that I'd like to fix in this PR.

Right now, `@types/react-confetti` is installed as a dev dependency.

https://github.com/ulitcos/react-canvas-confetti/blob/6ee951bb518cf7cb1d2c31e60b2b3848b434b516/package.json#L33

This is fine when working locally on this package (in the Storybook for example), but not when `react-canvas-confetti` is installed as a dependency in another TypeScript project: dev dependencies are not downloaded and there are type errors.

<img width="639" alt="Screenshot 2021-03-17 at 14 15 31" src="https://user-images.githubusercontent.com/35560568/111475520-71f39900-872d-11eb-9960-c88516c0338b.png">

☝️ `particleCount` is not assignable to `react-canvas-confetti`'s props, because it's defined in `canvas-confetti`'s types.

Moving this to a dependency will solve the issue.

(P.S. until this is merged and released, adding `@types/react-confetti` as a dev dependency of the other project will solve the TS compile-time errors)